### PR TITLE
Add a `string.unquote()` for the position because on new versions of …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wide/styles-utils",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "SCSS Utils Collection.",
   "license": "MIT",
   "author": "Julien Martins Da Costa (https://github.com/jdacosta)",

--- a/src/mixins/element.scss
+++ b/src/mixins/element.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use 'sass:math';
 @use 'sass:meta';
+@use 'sass:string';
 @use '../functions/list' as list;
 
 ///
@@ -140,8 +141,9 @@
 ///
 @mixin position($arglist...) {
   $map: meta.keywords($arglist);
+  $position: map.get($map, position) or list.nth-or-null($arglist, 1) or absolute;
 
-  position: map.get($map, position) or list.nth-or-null($arglist, 1) or absolute;
+  position: string.unquote($position);
   z-index: map.get($map, z-index) or list.nth-or-null($arglist, 6) or auto;
   top: map.get($map, top) or list.nth-or-null($arglist, 2) or 0;
   right: map.get($map, right) or list.nth-or-null($arglist, 3) or list.nth-or-null($arglist, 2) or 0;


### PR DESCRIPTION
…sass the position is returned with quotes